### PR TITLE
New option to send email during user creation and send it after the user is inserted in the database.

### DIFF
--- a/src/ZfcUserAdmin/Options/ModuleOptions.php
+++ b/src/ZfcUserAdmin/Options/ModuleOptions.php
@@ -40,6 +40,13 @@ class ModuleOptions extends AbstractOptions implements
      * false = administrator chooses password
      */
     protected $createUserAutoPassword = true;
+    
+    /**
+     * If it sends an email to the user after it's creation
+     * 
+     * @var bool
+     */
+    protected $createUserSendsEmail = false;
 
     protected $userMapper = 'ZfcUserAdmin\Mapper\UserDoctrine';
 
@@ -90,4 +97,15 @@ class ModuleOptions extends AbstractOptions implements
     {
         return $this->createUserAutoPassword;
     }
+    
+	public function getCreateUserSendsEmail()
+    {
+        return $this->createUserSendsEmail;
+    }
+
+	public function setCreateUserSendsEmail($createUserSendsEmail)
+    {
+        $this->createUserSendsEmail = $createUserSendsEmail;
+    }
+
 }

--- a/src/ZfcUserAdmin/Options/UserCreateOptionsInterface.php
+++ b/src/ZfcUserAdmin/Options/UserCreateOptionsInterface.php
@@ -11,4 +11,8 @@ interface UserCreateOptionsInterface
     public function getCreateFormElements();
 
     public function setCreateFormElements(array $elements);
+    
+    public function getCreateUserSendsEmail();
+    
+    public function setCreateUserSendsEmail($createUserSendsEmail);
 }

--- a/src/ZfcUserAdmin/Service/User.php
+++ b/src/ZfcUserAdmin/Service/User.php
@@ -49,8 +49,6 @@ class User extends EventProvider implements ServiceManagerAwareInterface
             $user->setPassword($rand);
         } else
 
-        //@TODO: Use ZfcMail(when ready)
-        mail($user->getEmail(), 'Password', 'Your password is: ' . $user->getPassword());
         $bcrypt = new Bcrypt;
         $bcrypt->setCost($zfcUserOptions->getPasswordCost());
         $user->setPassword($bcrypt->create($user->getPassword()));
@@ -71,6 +69,12 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('user' => $user, 'form' => $form, 'data' => $data));
         $this->getUserMapper()->insert($user);
         $this->getEventManager()->trigger(__FUNCTION__.'.post', $this, array('user' => $user, 'form' => $form, 'data' => $data));
+        
+        if ($this->getOptions()->getCreateUserSendsEmail()) {
+            //@TODO: Use ZfcMail(when ready)
+            mail($user->getEmail(), 'Password', 'Your password is: ' . $user->getPassword());
+        }
+        
         return $user;
     }
 


### PR DESCRIPTION
New option to check if need to send an email after user creation and
send it only after the user is inserted into the database, so if there
is an error there the user does not receive an "false" email.
