### PR TITLE
enable higher versions of zfc-user and zfc-admin inside composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zf-commons/zfc-user": "0.1.1",
-        "zf-commons/zfc-admin": "0.1.1"
+        "zf-commons/zfc-user": ">=0.1.1",
+        "zf-commons/zfc-admin": ">=0.1.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
zfc-commones requires 0.1.2 now, so tor un ZfcUserAdmin with up to date ZF2 modules 0.1.2 versions are needed.
Added ">=" to version numbering to solve that conflict.
