### PR TITLE
Added Missing Route Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ This module provides an interface to create/edit/delete users.
 
 ## Usage
 
+### Update The Application Config
+
+Add ZfcUserAdmin to the modules array in `application.config.php`
+
+    'modules' => array(
+        'Application',
+        'ZfcBase',
+        'ZfcUser',
+        'ZfcUserAdmin',
+        // ... more modules ... //
+        ),
+
 ### Override default module config
 
 Copy `<zfc-user-admin>/config/ZfcUserAdmin.global.php.dist` to `<project root>/autoload/ZfcUserAdmin.global.php` and
@@ -54,6 +66,21 @@ return array(
 );
 
 ```
+
+### Routing
+
+You will be able to access the users list from `/admin/user/list`
+
+This can be overridden by adding the routing information to the routes array your `module.config.php` file.  Adding the following:
+
+    'zfcadmin' => array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/site-admin',
+                ),
+            ),
+
+Will move the list to `/site-admin/user/list`
 
 TODO: add more usage information and module options list
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -13,6 +13,10 @@ return array(
     'router' => array(
         'routes' => array(
             'zfcadmin' => array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/admin',
+                ),
                 'child_routes' => array(
                     'zfcuseradmin' => array(
                         'type' => 'Literal',


### PR DESCRIPTION
I added in the missing route information with a default of `/admin` and updated the docs with instructions on what the defaults are, and how to override them.
