### PR TITLE
Corrected navigation for create user page

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -82,7 +82,7 @@ return array(
                 'pages' => array(
                     'create' => array(
                         'label' => 'New User',
-                        'route' => 'admin/create',
+                        'route' => 'zfcadmin/zfcuseradmin/create',
                     ),
                 ),
             ),


### PR DESCRIPTION
The navigation to the create user page is wrong - there is no such route. It breaks the navigation when trying to render with maxDepth > 0. 
I corrected it to the right route.
