### PR TITLE
Added support for bootstrap v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZfcUserAdmin Module for Zend Framework 2
 
-Version 0.1
+Version 0.2
 
 ## Introduction
 

--- a/view/zfc-user-admin/user-admin/_form.phtml
+++ b/view/zfc-user-admin/user-admin/_form.phtml
@@ -1,25 +1,33 @@
+<?php $form->setAttribute('role', 'form'); ?>
 <?php echo $this->form()->openTag($form) ?>
-    <dl class="zend_form">
-        <?php foreach ($form as $element): ?>
-            <?php $isButton = $element instanceof Zend\Form\Element\Button; ?>
-            <?php $isCheckbox = $element instanceof Zend\Form\Element\Checkbox || $element->getAttribute('type') == 'checkbox'; ?>
-            <?php if ($element->getLabel() != null && !$isButton): ?>
-                <dt><?php echo $this->formLabel($element) ?></dt>
-            <?php endif ?>
-            <?php if ($isButton): ?>
-                <dd><?php echo $this->formButton($element) ?></dd>
-            <?php elseif ($element instanceof Zend\Form\Element\Select): ?>
-                <dd><?php echo $this->formSelect($element) . $this->formElementErrors($element) ?></dd>
-            <?php elseif ($element instanceof Zend\Form\Element\MultiCheckbox): ?>
-                <dd><?php echo $this->formMultiCheckbox($element) . $this->formElementErrors($element) ?></dd>
-            <?php elseif ($isCheckbox): ?>
-                <dd><?php echo $this->formCheckbox($element) ?></dd>
-            <?php else: ?>
-                <dd><?php echo $this->formInput($element) . $this->formElementErrors($element) ?></dd>
-            <?php endif ?>
-        <?php endforeach ?>
-    </dl>
+    <?php foreach ($form as $element): ?>
+        <?php $isButton = $element instanceof Zend\Form\Element\Button; ?>
+        <?php $isCheckbox = $element instanceof Zend\Form\Element\Checkbox || $element->getAttribute('type') == 'checkbox'; ?>
+        <?php if ($element->getLabel() != null && !$isButton && !$isCheckbox): ?>
+            <?php echo $this->formLabel($element) ?>
+        <?php endif ?>
+        <?php if ($isButton): ?>
+            <?php $element->setAttribute('class', 'btn btn-default'); ?>
+            <?php echo $this->formButton($element) ?>
+        <?php elseif ($element instanceof Zend\Form\Element\Select): ?>
+            <?php echo $this->formSelect($element) . $this->formElementErrors($element) ?>
+        <?php elseif ($element instanceof Zend\Form\Element\MultiCheckbox): ?>
+             <div class="checkbox">
+                <?php echo $this->formMultiCheckbox($element) . $this->formElementErrors($element) ?>
+             </div>    
+        <?php elseif ($isCheckbox): ?>
+            <?php $element->setUseHiddenElement(false); ?>
+            <div class="checkbox">
+                <label><?php echo $this->formCheckbox($element) . $element->getLabel() ?></label>
+            </div>
+        <?php else: ?>
+             <div class="form-group">
+                <?php $element->setAttribute('class', 'form-control'); ?>
+                <?php echo $this->formInput($element) . $this->formElementErrors($element) ?>    
+            </div>
+        <?php endif ?>
+<?php endforeach ?>
 <?php if ($this->redirect): ?>
     <input type="hidden" name="redirect" value="<?php echo $this->redirect ?>">
 <?php endif ?>
-<?php echo $this->form()->closeTag() ?>
+<?php echo $this->form()->closeTag();


### PR DESCRIPTION
I updated the _form.phtml file to support bootstrap v3. 
Bootstrap v3 will display the old _form.phtml template with no design at all, as it requires certain classes and structure.
Now it supports both v2 and v3.
