### PR TITLE
Binding User to Edit Form fixes issues #30 and #31

### DIFF
--- a/src/ZfcUserAdmin/Controller/UserAdminController.php
+++ b/src/ZfcUserAdmin/Controller/UserAdminController.php
@@ -72,7 +72,7 @@ class UserAdminController extends AbstractActionController
 
         /** @var $form \ZfcUserAdmin\Form\EditUser */
         $form = $this->getServiceLocator()->get('zfcuseradmin_edituser_form');
-        $form->setUser($user);
+        $form->bind($user);
 
         /** @var $request \Zend\Http\Request */
         $request = $this->getRequest();

--- a/src/ZfcUserAdmin/Controller/UserAdminController.php
+++ b/src/ZfcUserAdmin/Controller/UserAdminController.php
@@ -47,7 +47,8 @@ class UserAdminController extends AbstractActionController
             $zfcUserOptions = $this->getZfcUserOptions();
             $class = $zfcUserOptions->getUserEntityClass();
             $user = new $class();
-            $form->setHydrator(new ClassMethods());
+            $hydrator = $this->getServiceLocator()->get('zfcuser_user_hydrator');
+            $form->setHydrator($hydrator);
             $form->bind($user);
             $form->setData($request->getPost());
 
@@ -72,6 +73,8 @@ class UserAdminController extends AbstractActionController
 
         /** @var $form \ZfcUserAdmin\Form\EditUser */
         $form = $this->getServiceLocator()->get('zfcuseradmin_edituser_form');
+        $hydrator = $this->getServiceLocator()->get('zfcuser_user_hydrator');
+        $form->setHydrator($hydrator);
         $form->bind($user);
 
         /** @var $request \Zend\Http\Request */

--- a/src/ZfcUserAdmin/Service/User.php
+++ b/src/ZfcUserAdmin/Service/User.php
@@ -77,16 +77,8 @@ class User extends EventProvider implements ServiceManagerAwareInterface
      */
     public function edit(Form $form, array $data, UserInterface $user)
     {
-        // first, process all form fields
-        foreach ($data as $key => $value) {
-            if ($key == 'password') continue;
-
-            $setter = $this->getAccessorName($key);
-            if (method_exists($user, $setter)) call_user_func(array($user, $setter), $value);
-        }
-
         $argv = array();
-        // then check if admin wants to change user password
+        // check if admin wants to change user password
         if ($this->getOptions()->getAllowPasswordChange()) {
             if (!empty($data['reset_password'])) {
                 $argv['password'] = Rand::getString(8);
@@ -99,11 +91,6 @@ class User extends EventProvider implements ServiceManagerAwareInterface
                 $bcrypt->setCost($this->getZfcUserOptions()->getPasswordCost());
                 $user->setPassword($bcrypt->create($argv['password']));
             }
-        }
-
-        // TODO: not sure if this code is required here - all fields that came from the form already saved
-        foreach ($this->getOptions()->getEditFormElements() as $element) {
-            call_user_func(array($user, $this->getAccessorName($element)), $data[$element]);
         }
 
         $argv += array('user' => $user, 'form' => $form, 'data' => $data);


### PR DESCRIPTION
These changes are just a proposal for solution for the following issues:
- https://github.com/Danielss89/ZfcUserAdmin/issues/30
- https://github.com/Danielss89/ZfcUserAdmin/issues/31

I have not edited further code since I can't tell yet what consequences this will have on
- custom form elements
- `EditUser` Form `setUser` event see https://github.com/Danielss89/ZfcUserAdmin/blob/master/src/ZfcUserAdmin/Form/EditUser.php#L72-76
- `EditUser` Form `populateFromUser()` method see https://github.com/Danielss89/ZfcUserAdmin/blob/master/src/ZfcUserAdmin/Form/EditUser.php#L83-99
  and others.

But - similar to binding the `User` to the `CreateUser` Form inside the `createAction` method,
this scenario works with _Doctrine_'s ORM with `OneToOne` and `ManyToMany` relationships.

Any thoughts, @Danielss89 ?
