### PR TITLE
Fixed default userMapper

### DIFF
--- a/config/ZfcUserAdmin.global.php.dist
+++ b/config/ZfcUserAdmin.global.php.dist
@@ -6,8 +6,6 @@
  * drop this config file in it and change the values as you wish.
  */
 $settings = array(
-    
-
     /**
      * Mapper for ZfcUser
      *
@@ -19,7 +17,7 @@ $settings = array(
      * By default this is using
      * ZfcUserAdmin\Mapper\UserZendDb
      */
-    'user_mapper' => 'ZfcUserAdmin\Mapper\UserDoctrine',
+    'user_mapper' => 'ZfcUserAdmin\Mapper\UserZendDb',
 );
 
 /**

--- a/src/ZfcUserAdmin/Options/ModuleOptions.php
+++ b/src/ZfcUserAdmin/Options/ModuleOptions.php
@@ -54,7 +54,7 @@ class ModuleOptions extends AbstractOptions implements
      */
     protected $allowPasswordChange = true;
 
-    protected $userMapper = 'ZfcUserAdmin\Mapper\UserDoctrine';
+    protected $userMapper = 'ZfcUserAdmin\Mapper\UserZendDb';
 
     public function setUserMapper($userMapper)
     {


### PR DESCRIPTION
Changed the default of the mapper to the ZendDB variant like the text abive siad it was.
Didnt use the doctyrine as default because the extra dependecy's that are needed in that case for zenfDB it's working out of the box.
