### PR TITLE
Form Simplification and Upgrade [potential BC]

### DIFF
--- a/config/services.config.php
+++ b/config/services.config.php
@@ -4,96 +4,16 @@
  * Date: 3/18/13
  * Time: 6:39 PM
  */
-use Zend\ServiceManager\ServiceLocatorInterface;
-use ZfcUser\Form\RegisterFilter;
-use ZfcUser\Mapper\UserHydrator;
-use ZfcUser\Validator\NoRecordExists;
-use ZfcUserAdmin\Form;
-use ZfcUserAdmin\Options;
-use ZfcUserAdmin\Validator\NoRecordExistsEdit;
 
 return array(
     'invokables' => array(
-        'ZfcUserAdmin\Form\EditUser' => 'ZfcUserAdmin\Form\EditUser',
-        'zfcuseradmin_user_service' => 'ZfcUserAdmin\Service\User',
+        'ZfcUserAdmin\Form\EditUser'        => 'ZfcUserAdmin\Form\EditUser',
+        'zfcuseradmin_user_service'         => 'ZfcUserAdmin\Service\User',
     ),
     'factories' => array(
-        'zfcuseradmin_module_options' => function (ServiceLocatorInterface $sm) {
-            $config = $sm->get('Config');
-            return new Options\ModuleOptions(isset($config['zfcuseradmin']) ? $config['zfcuseradmin'] : array());
-        },
-        'zfcuseradmin_edituser_form' => function (ServiceLocatorInterface $sm) {
-            /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
-            $zfcUserOptions = $sm->get('zfcuser_module_options');
-            /** @var $zfcUserAdminOptions \ZfcUserAdmin\Options\ModuleOptions */
-            $zfcUserAdminOptions = $sm->get('zfcuseradmin_module_options');
-            $form = new Form\EditUser(null, $zfcUserAdminOptions, $zfcUserOptions, $sm);
-            $filter = new RegisterFilter(
-                new NoRecordExistsEdit(array(
-                    'mapper' => $sm->get('zfcuser_user_mapper'),
-                    'key' => 'email'
-                )),
-                new NoRecordExistsEdit(array(
-                    'mapper' => $sm->get('zfcuser_user_mapper'),
-                    'key' => 'username'
-                )),
-                $zfcUserOptions
-            );
-            if (!$zfcUserAdminOptions->getAllowPasswordChange()) {
-                $filter->remove('password')->remove('passwordVerify');
-            } else {
-                $filter->get('password')->setRequired(false);
-                $filter->remove('passwordVerify');
-            }
-            $form->setInputFilter($filter);
-            return $form;
-        },
-        'zfcuseradmin_createuser_form' => function (ServiceLocatorInterface $sm) {
-            /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
-            $zfcUserOptions = $sm->get('zfcuser_module_options');
-            /** @var $zfcUserAdminOptions \ZfcUserAdmin\Options\ModuleOptions */
-            $zfcUserAdminOptions = $sm->get('zfcuseradmin_module_options');
-            $form = new Form\CreateUser(null, $zfcUserAdminOptions, $zfcUserOptions, $sm);
-            $filter = new RegisterFilter(
-                new NoRecordExists(array(
-                    'mapper' => $sm->get('zfcuser_user_mapper'),
-                    'key' => 'email'
-                )),
-                new NoRecordExists(array(
-                    'mapper' => $sm->get('zfcuser_user_mapper'),
-                    'key' => 'username'
-                )),
-                $zfcUserOptions
-            );
-            if ($zfcUserAdminOptions->getCreateUserAutoPassword()) {
-                $filter->remove('password')->remove('passwordVerify');
-            }
-            $form->setInputFilter($filter);
-            return $form;
-        },
-        'zfcuser_user_mapper' => function (ServiceLocatorInterface $sm) {
-            /** @var $config \ZfcUserAdmin\Options\ModuleOptions */
-            $config = $sm->get('zfcuseradmin_module_options');
-            $mapperClass = $config->getUserMapper();
-            if (stripos($mapperClass, 'doctrine') !== false) {
-                $mapper = new $mapperClass(
-                    $sm->get('zfcuser_doctrine_em'),
-                    $sm->get('zfcuser_module_options')
-                );
-            } else {
-                /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
-                $zfcUserOptions = $sm->get('zfcuser_module_options');
-
-                /** @var $mapper \ZfcUserAdmin\Mapper\UserZendDb */
-                $mapper = new $mapperClass();
-                $mapper->setDbAdapter($sm->get('zfcuser_zend_db_adapter'));
-                $entityClass = $zfcUserOptions->getUserEntityClass();
-                $mapper->setEntityPrototype(new $entityClass);
-                $mapper->setHydrator($sm->get('zfcuser_user_hydrator'));
-                $mapper->setTableName($zfcUserOptions->getTableName());
-            }
-
-            return $mapper;
-        },
+        'zfcuseradmin_module_options'       => 'ZfcUserAdmin\Factory\Options\ModuleOptionsFactory',
+        'zfcuser_user_mapper'               => 'ZfcUserAdmin\Factory\Mapper\UserZendDbFactory',
+        'zfcuseradmin_createuser_form'      => 'ZfcUserAdmin\Factory\Form\CreateUserFactory',
+        'zfcuseradmin_edituser_form'        => 'ZfcUserAdmin\Factory\Form\EditUserFactory',
     ),
 );

--- a/src/ZfcUserAdmin/Factory/Form/CreateUserFactory.php
+++ b/src/ZfcUserAdmin/Factory/Form/CreateUserFactory.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Clayton Daley
+ * Date: 1/31/2015
+ * Time: 1:06 PM
+ */
+
+namespace ZfcUserAdmin\Factory\Form;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUser\Form\RegisterFilter;
+use ZfcUser\Validator\NoRecordExists;
+use ZfcUserAdmin\Form\CreateUser;
+
+class CreateUserFactory implements FactoryInterface {
+
+    function createService(ServiceLocatorInterface $serviceLocator) {
+        /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
+        $zfcUserOptions = $serviceLocator->get('zfcuser_module_options');
+        /** @var $zfcUserAdminOptions \ZfcUserAdmin\Options\ModuleOptions */
+        $zfcUserAdminOptions = $serviceLocator->get('zfcuseradmin_module_options');
+        $form = new CreateUser(null, $zfcUserAdminOptions, $zfcUserOptions, $serviceLocator);
+        $filter = new RegisterFilter(
+            new NoRecordExists(array(
+                'mapper' => $serviceLocator->get('zfcuser_user_mapper'),
+                'key' => 'email'
+            )),
+            new NoRecordExists(array(
+                'mapper' => $serviceLocator->get('zfcuser_user_mapper'),
+                'key' => 'username'
+            )),
+            $zfcUserOptions
+        );
+        if ($zfcUserAdminOptions->getCreateUserAutoPassword()) {
+            $filter->remove('password')->remove('passwordVerify');
+        }
+        $form->setInputFilter($filter);
+        return $form;
+    }
+}

--- a/src/ZfcUserAdmin/Factory/Form/EditUserFactory.php
+++ b/src/ZfcUserAdmin/Factory/Form/EditUserFactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Clayton Daley
+ * Date: 1/31/2015
+ * Time: 1:03 PM
+ */
+
+namespace ZfcUserAdmin\Factory\Form;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUser\Form\RegisterFilter;
+use ZfcUserAdmin\Form\EditUser;
+use ZfcUserAdmin\Validator\NoRecordExistsEdit;
+
+class EditUserFactory implements FactoryInterface {
+
+    public function createService(ServiceLocatorInterface $serviceLocator) {
+        /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
+        $zfcUserOptions = $serviceLocator->get('zfcuser_module_options');
+        /** @var $zfcUserAdminOptions \ZfcUserAdmin\Options\ModuleOptions */
+        $zfcUserAdminOptions = $serviceLocator->get('zfcuseradmin_module_options');
+        $form = new EditUser(null, $zfcUserAdminOptions, $zfcUserOptions, $serviceLocator);
+        $filter = new RegisterFilter(
+            new NoRecordExistsEdit(array(
+                'mapper' => $serviceLocator->get('zfcuser_user_mapper'),
+                'key' => 'email'
+            )),
+            new NoRecordExistsEdit(array(
+                'mapper' => $serviceLocator->get('zfcuser_user_mapper'),
+                'key' => 'username'
+            )),
+            $zfcUserOptions
+        );
+        if (!$zfcUserAdminOptions->getAllowPasswordChange()) {
+            $filter->remove('password')->remove('passwordVerify');
+        } else {
+            $filter->get('password')->setRequired(false);
+            $filter->remove('passwordVerify');
+        }
+        $form->setInputFilter($filter);
+        return $form;
+    }
+}

--- a/src/ZfcUserAdmin/Factory/Mapper/UserZendDbFactory.php
+++ b/src/ZfcUserAdmin/Factory/Mapper/UserZendDbFactory.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Clayton Daley
+ * Date: 1/31/2015
+ * Time: 1:09 PM
+ */
+
+namespace ZfcUserAdmin\Factory\Mapper;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class UserZendDbFactory implements FactoryInterface {
+
+    public function createService(ServiceLocatorInterface $serviceLocator) {
+        /** @var $config \ZfcUserAdmin\Options\ModuleOptions */
+        $config = $serviceLocator->get('zfcuseradmin_module_options');
+        $mapperClass = $config->getUserMapper();
+        if (stripos($mapperClass, 'doctrine') !== false) {
+            $mapper = new $mapperClass(
+                $serviceLocator->get('zfcuser_doctrine_em'),
+                $serviceLocator->get('zfcuser_module_options')
+            );
+        } else {
+            /** @var $zfcUserOptions \ZfcUser\Options\UserServiceOptionsInterface */
+            $zfcUserOptions = $serviceLocator->get('zfcuser_module_options');
+
+            /** @var $mapper \ZfcUserAdmin\Mapper\UserZendDb */
+            $mapper = new $mapperClass();
+            $mapper->setDbAdapter($serviceLocator->get('zfcuser_zend_db_adapter'));
+            $entityClass = $zfcUserOptions->getUserEntityClass();
+            $mapper->setEntityPrototype(new $entityClass);
+            $mapper->setHydrator($serviceLocator->get('zfcuser_user_hydrator'));
+            $mapper->setTableName($zfcUserOptions->getTableName());
+        }
+
+        return $mapper;
+    }
+}

--- a/src/ZfcUserAdmin/Factory/Options/ModuleOptionsFactory.php
+++ b/src/ZfcUserAdmin/Factory/Options/ModuleOptionsFactory.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Clayton Daley
+ * Date: 1/31/2015
+ * Time: 1:13 PM
+ */
+
+namespace ZfcUserAdmin\Factory\Options;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUserAdmin\Options\ModuleOptions;
+
+class ModuleOptionsFactory implements FactoryInterface {
+
+    public function createService(ServiceLocatorInterface $serviceLocator) {
+        $config = $serviceLocator->get('Config');
+        return new ModuleOptions(isset($config['zfcuseradmin']) ? $config['zfcuseradmin'] : array());
+    }
+}

--- a/src/ZfcUserAdmin/Form/CreateUser.php
+++ b/src/ZfcUserAdmin/Form/CreateUser.php
@@ -2,9 +2,10 @@
 
 namespace ZfcUserAdmin\Form;
 
-use ZfcUserAdmin\Options\UserCreateOptionsInterface;
+use Zend\Stdlib\Hydrator\ClassMethods;
 use ZfcUser\Options\RegistrationOptionsInterface;
 use ZfcUser\Form\Register as Register;
+use ZfcUserAdmin\Options\UserCreateOptionsInterface;
 
 class CreateUser extends Register
 {
@@ -24,6 +25,8 @@ class CreateUser extends Register
         $this->setCreateOptions($createOptions);
         $this->setServiceManager($serviceManager);
         parent::__construct($name, $registerOptions);
+        // ZfcUser should have setHydrator() which we replace or extend
+        $this->setHydrator($serviceManager->get('zfcuser_user_hydrator'));
 
         if ($createOptions->getCreateUserAutoPassword()) {
             $this->remove('password');
@@ -67,5 +70,35 @@ class CreateUser extends Register
     public function getServiceManager()
     {
         return $this->serviceManager;
+    }
+
+    /**
+     * Override isValid() to set an validation group of all elements that do not
+     * have an 'exclude' option, if at least one element has this option set.
+     *
+     * @return boolean
+     */
+    public function isValid()
+    {
+        if ($this->hasValidated) {
+            return $this->isValid;
+        }
+
+        if ($this->getValidationGroup() === null) {
+            // Add all non-excluded elements to the validation group
+            $validationGroup = null;
+            foreach ($this->getElements() as $element) {
+                if ($element->getOption('exclude') === false or
+                    ($element->getAttribute('readonly') !== true && $element->getOption('exclude') !== true))
+                {
+                    $validationGroup[] = $element->getName();
+                }
+            }
+            if ($validationGroup) {
+                $this->setValidationGroup($validationGroup);
+            }
+        }
+
+        return parent::isValid();
     }
 }

--- a/src/ZfcUserAdmin/Service/User.php
+++ b/src/ZfcUserAdmin/Service/User.php
@@ -41,26 +41,20 @@ class User extends EventProvider implements ServiceManagerAwareInterface
     /**
      * @param Form $form
      * @param array $data
-     * @return UserInterface|null
+     * @param UserInterface $user
+     * @return UserInterface
      */
-    public function create(Form $form, array $data)
+    public function create(Form $form, array $data, UserInterface $user)
     {
-        $zfcUserOptions = $this->getZfcUserOptions();
-        $user = $form->getData();
-
         $argv = array();
         if ($this->getOptions()->getCreateUserAutoPassword()) {
             $argv['password'] = $this->generatePassword();
         } else {
-            $argv['password'] = $user->getPassword();
+            $argv['password'] = $data['password'];
         }
-        $bcrypt = new Bcrypt;
-        $bcrypt->setCost($zfcUserOptions->getPasswordCost());
+        $bcrypt = new Bcrypt();
+        $bcrypt->setCost($this->getZfcUserOptions()->getPasswordCost());
         $user->setPassword($bcrypt->create($argv['password']));
-
-        foreach ($this->getOptions()->getCreateFormElements() as $element) {
-            call_user_func(array($user, $this->getAccessorName($element)), $data[$element]);
-        }
 
         $argv += array('user' => $user, 'form' => $form, 'data' => $data);
         $this->getEventManager()->trigger(__FUNCTION__, $this, $argv);
@@ -77,18 +71,10 @@ class User extends EventProvider implements ServiceManagerAwareInterface
      */
     public function edit(Form $form, array $data, UserInterface $user)
     {
-        // first, process all form fields
-        foreach ($data as $key => $value) {
-            if ($key == 'password') continue;
-
-            $setter = $this->getAccessorName($key);
-            if (method_exists($user, $setter)) call_user_func(array($user, $setter), $value);
-        }
-
         $argv = array();
         // then check if admin wants to change user password
         if ($this->getOptions()->getAllowPasswordChange()) {
-            if (!empty($data['reset_password'])) {
+            if (!empty($data['generate_password'])) {
                 $argv['password'] = $this->generatePassword();
             } elseif (!empty($data['password'])) {
                 $argv['password'] = $data['password'];
@@ -99,11 +85,6 @@ class User extends EventProvider implements ServiceManagerAwareInterface
                 $bcrypt->setCost($this->getZfcUserOptions()->getPasswordCost());
                 $user->setPassword($bcrypt->create($argv['password']));
             }
-        }
-
-        // TODO: not sure if this code is required here - all fields that came from the form already saved
-        foreach ($this->getOptions()->getEditFormElements() as $element) {
-            call_user_func(array($user, $this->getAccessorName($element)), $data[$element]);
         }
 
         $argv += array('user' => $user, 'form' => $form, 'data' => $data);
@@ -119,15 +100,6 @@ class User extends EventProvider implements ServiceManagerAwareInterface
     public function generatePassword()
     {
         return Rand::getString($this->getOptions()->getAutoPasswordLength());
-    }
-
-    protected function getAccessorName($property, $set = true)
-    {
-        $parts = explode('_', $property);
-        array_walk($parts, function (&$val) {
-            $val = ucfirst($val);
-        });
-        return (($set ? 'set' : 'get') . implode('', $parts));
     }
 
     public function getUserMapper()


### PR DESCRIPTION
NOTE:  This PR requires [ZfcUser PR #562](https://github.com/ZF-Commons/ZfcUser/pull/562) and [ZfcUser PR #564](https://github.com/ZF-Commons/ZfcUser/pull/564)

NOTE:  This PR may break backwards compatibility because it defaults to underscore notation for form fields.  This could be changed by supporting a [flag on the hydrator](http://framework.zend.com/apidoc/2.3/classes/Zend.Stdlib.Hydrator.ClassMethods.html), but we won't necessarily know the right defaults for all users.

This patch now rewrites significant parts of ZfcUserAdmin:
- Closures are replaced by factories for [performance reasons](http://stackoverflow.com/questions/14667621/zf2-optimize-for-high-traffic) (see section 3 in top answer)
- Forms now use the `bind()` pattern.  This covers all changes in PR #50 except that the hydrator is created in `__construct` so it is available to extend during the 'init' event.
- Forms now provide an enhanced Validation Group strategy.  A modest improvement on  [Rob Allen's recommendation](http://akrabat.com/zend-framework-2/exclude-elements-from-zendforms-getdata/), elements can be individually excluded using an attribute/option.  This enhances extensibility.
- At some point, I expect the Hydrator initialization and Validation Group changes to be migrated to ZfcUser's forms, but this will provide the capability to 1.x users during the transition.

This eliminated the need for lots of support infrastructure in these classes.  As a side-effect, the new code supports a broader set of Zend Form features.

P.S. Due to the increased size of this change -- and the simplicity and power of the form change --, I moved it to a separate PR. 
