### PR TITLE
Generic Form Builder

### DIFF
--- a/view/zfc-user-admin/user-admin/_form.phtml
+++ b/view/zfc-user-admin/user-admin/_form.phtml
@@ -1,22 +1,10 @@
 <?php echo $this->form()->openTag($form) ?>
     <dl class="zend_form">
         <?php foreach ($form as $element): ?>
-            <?php $isButton = $element instanceof Zend\Form\Element\Button; ?>
-            <?php $isCheckbox = $element instanceof Zend\Form\Element\Checkbox || $element->getAttribute('type') == 'checkbox'; ?>
             <?php if ($element->getLabel() != null && !$isButton): ?>
                 <dt><?php echo $this->formLabel($element) ?></dt>
             <?php endif ?>
-            <?php if ($isButton): ?>
-                <dd><?php echo $this->formButton($element) ?></dd>
-            <?php elseif ($element instanceof Zend\Form\Element\Select): ?>
-                <dd><?php echo $this->formSelect($element) . $this->formElementErrors($element) ?></dd>
-            <?php elseif ($element instanceof Zend\Form\Element\MultiCheckbox): ?>
-                <dd><?php echo $this->formMultiCheckbox($element) . $this->formElementErrors($element) ?></dd>
-            <?php elseif ($isCheckbox): ?>
-                <dd><?php echo $this->formCheckbox($element) ?></dd>
-            <?php else: ?>
-                <dd><?php echo $this->formInput($element) . $this->formElementErrors($element) ?></dd>
-            <?php endif ?>
+            <dd><?php echo $this->formElement($element) . $this->formElementErrors($element) ?></dd>
         <?php endforeach ?>
     </dl>
 <?php if ($this->redirect): ?>

--- a/view/zfc-user-admin/user-admin/_form.phtml
+++ b/view/zfc-user-admin/user-admin/_form.phtml
@@ -1,7 +1,7 @@
 <?php echo $this->form()->openTag($form) ?>
     <dl class="zend_form">
         <?php foreach ($form as $element): ?>
-            <?php if ($element->getLabel() != null && !$isButton): ?>
+            <?php if ($element->getLabel() != null && !$element instanceof Zend\Form\Element\Button): ?>
                 <dt><?php echo $this->formLabel($element) ?></dt>
             <?php endif ?>
             <dd><?php echo $this->formElement($element) . $this->formElementErrors($element) ?></dd>


### PR DESCRIPTION
Rather than add more and more specialized calls, this builder takes advantage of the generic `formElement` to correctly render all element types.  It could be enhanced with the tags and classes from #63 if desired, but I'm unclear on the generic attitude of Zfc\* towards this change so it's not included here.
